### PR TITLE
ci: 🎡 外部アクションのバージョン指定をハッシュで行うようにした

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -30,13 +30,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: $ git clone する
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: pnpm のセットアップを行う
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 10.7.0
       - name: Node.js のセットアップを行う
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: '.node-version'
           cache: pnpm
@@ -83,7 +83,7 @@ jobs:
           echo '[LOG] grep -q "ネコを登場させられる" ./output/screenshot_ocr_rewards-gyakuhiki.txt'
           grep -q "ネコを登場させられる" ./output/screenshot_ocr_rewards-gyakuhiki.txt
       - name: capture-website-cli で撮影したスクショ と OCR のテキストファイル を Artifacts に保存する
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: capture-website


### PR DESCRIPTION
- セキュリティ上の問題を回避するため
- close https://github.com/eiyuden-chronicle/eiyuden-shinsho/issues/1031